### PR TITLE
match current behavior of "normal" infura endpoint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ function createInfuraMiddleware({ network = 'mainnet' }) {
     const rawData = await response.text()
     // special case for now
     if (req.method === 'eth_getBlockByNumber' && rawData === 'Not Found') {
-      err.result = null
+      res.result = null
       return
     }
     const data = JSON.parse(rawData)


### PR DESCRIPTION
not sure if just a miss or intentional but the normal behavior is have the res.result be null and error is not defined when this happens so it throws an error